### PR TITLE
lang ja: VizVid

### DIFF
--- a/Packages/idv.jlchntoz.vvmw/Resources/lang.json
+++ b/Packages/idv.jlchntoz.vvmw/Resources/lang.json
@@ -130,7 +130,7 @@
     "_name": "日本語",
     "_vrclang": "ja",
     "_timezone": "Tokyo Standard Time",
-    "VVMW_Name": "ビズビッド",
+    "VVMW_Name": "VizVid",
     "Sync": "同期",
     "GlobalSync": "グローバル同期",
     "Reload": "再同期",


### PR DESCRIPTION
In Japanese, English proper nouns are often more natural when written as they are in English.