### PR TITLE
end_of_line = lf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 [*]
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 dotnet_style_qualification_for_field = false:silent
 dotnet_style_qualification_for_property = false:silent


### PR DESCRIPTION
I edited the lang.json in VSCode and VSCode saves the file by CRLF that is configured by editorconfig but lang.ja in repo is LF.
In `git config core.autocrlf == false` env, this is confused.