### PR TITLE
Added a button to reverse playlist order

### DIFF
--- a/Packages/idv.jlchntoz.vvmw/Editor/VVMW/PlayListEditorWindow.cs
+++ b/Packages/idv.jlchntoz.vvmw/Editor/VVMW/PlayListEditorWindow.cs
@@ -112,6 +112,9 @@ namespace JLChnToZ.VRC.VVMW.Editors {
                             using (new EditorGUI.DisabledGroupScope(selectedPlayList.entries == null || selectedPlayList.entries.Count == 0))
                                 if (GUILayout.Button("Fetch Titles", GUILayout.ExpandWidth(false)))
                                     FetchTitles().Forget();
+                            using (new EditorGUI.DisabledGroupScope(selectedPlayList.entries == null || selectedPlayList.entries.Count == 0))
+                                if (GUILayout.Button("Reverse Playlist", GUILayout.ExpandWidth(false)))
+                                    ReversePlaylist();
                         }
                     }
                 }
@@ -781,6 +784,12 @@ namespace JLChnToZ.VRC.VVMW.Editors {
                 entry.title = entries[i].title;
                 selectedPlayList.entries[i] = entry;
             }
+            isDirty = true;
+        }
+
+        void ReversePlaylist() {
+            if (selectedPlayList.entries == null || selectedPlayList.entries.Count == 0) return;
+            selectedPlayList.entries.Reverse();
             isDirty = true;
         }
 


### PR DESCRIPTION
Sometimes the imported youtube playlists come in an undesirable order, which makes it hard to watch a series sequentially from oldest - to the newest video.

This adds a simple "Reverse Playlist" button to quickly flip the order of the playlist without needing to manually drag elements around.

https://github.com/JLChnToZ/VVMW/assets/3798928/f49246ce-41ba-4fb6-a2a8-26a87b804520

