### PR TITLE
Show duration only if title is empty

### DIFF
--- a/Packages/idv.jlchntoz.vvmw/Runtime/VVMW/UIHandler_Progress.cs
+++ b/Packages/idv.jlchntoz.vvmw/Runtime/VVMW/UIHandler_Progress.cs
@@ -41,7 +41,7 @@ namespace JLChnToZ.VRC.VVMW {
                     progressSlider.interactable = false;
                 }
             } else {
-                SetStatusEnabled(false);
+                SetStatusEnabled(!string.IsNullOrEmpty(core.title));
                 var time = TimeSpan.FromSeconds(core.Time);
                 var durationTS = TimeSpan.FromSeconds(duration);
                 SetText(durationText, durationTMPro, string.Format(languageManager.GetLocale("TimeFormat"), durationTS));


### PR DESCRIPTION
This now shows the title on UI (Narrow) instead of the duration, which I believe most people would prefer. It can be modified to have a serialized toggle, if you'd like.